### PR TITLE
Update `FromFunc` to use a delegate

### DIFF
--- a/OpenAI/Functions/SchemaGenerator.cs
+++ b/OpenAI/Functions/SchemaGenerator.cs
@@ -12,8 +12,9 @@ namespace OpenAI.Functions;
 
 internal class SchemaGenerator
 {
-    public static Function GenerateSchema(MethodInfo method)
+    public static Function GenerateSchema(Delegate @delegate)
     {
+        var method = @delegate.Method;
         var functionAttribute = method.GetCustomAttribute<FunctionDefinitionAttribute>();
         var functionName = functionAttribute?.Name ?? method.Name;
         var functionDescription = functionAttribute?.Description;
@@ -66,7 +67,7 @@ internal class SchemaGenerator
             Name = functionName,
             Description = functionDescription,
             Parameters = parameters,
-            _method = method
+            Delegate = @delegate
         };
 
         return function;


### PR DESCRIPTION
[MAJOR VERSION UP] BREAKING CHANGE 

Updated `FromFunc` to use a delegate so that a string and instance is not needed to identify the target function. 

Unfortunatelly you cannot use a self-defined delegate to ensure the return type is as we expect as this also restricts the paramters. Generic Delegate will have to do and still offers a more type safe declaritive API. 